### PR TITLE
Support gnome 48

### DIFF
--- a/solaar-extension@sidevesh/metadata.json
+++ b/solaar-extension@sidevesh/metadata.json
@@ -4,7 +4,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/sidevesh/solaar-extension-for-gnome",
   "uuid": "solaar-extension@sidevesh",


### PR DESCRIPTION
Hi! Thank you for your work. I tested the extension on GNOME 48 with Arch Linux, and fortunately, it seems like there are no breaking changes from GNOME 47. I have just updated the `metadata.json` file.