### PR TITLE
Add Gnome 50 support

### DIFF
--- a/solaar-extension@sidevesh/metadata.json
+++ b/solaar-extension@sidevesh/metadata.json
@@ -6,7 +6,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/sidevesh/solaar-extension-for-gnome",
   "uuid": "solaar-extension@sidevesh",


### PR DESCRIPTION
Hey, going by the previous PRs (https://github.com/sidevesh/solaar-extension-for-gnome/pull/9 https://github.com/sidevesh/solaar-extension-for-gnome/pull/7) I'm modifying the metadata to add gnome 50 support.